### PR TITLE
Convert to using Go 1.7 Context for parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HttpRouter [![Build Status](https://travis-ci.org/julienschmidt/httprouter.svg?branch=master)](https://travis-ci.org/julienschmidt/httprouter) [![Coverage](https://gocover.io/_badge/github.com/julienschmidt/httprouter?1)](https://gocover.io/github.com/julienschmidt/httprouter) [![GoDoc](https://godoc.org/github.com/julienschmidt/httprouter?status.svg)](http://godoc.org/github.com/julienschmidt/httprouter)
+# HttpRouter [![GoDoc](https://godoc.org/github.com/bouk/httprouter?status.svg)](http://godoc.org/github.com/bouk/httprouter)
 
 HttpRouter is a lightweight high performance HTTP request router (also called *multiplexer* or just *mux* for short) for [Go](https://golang.org/).
 
@@ -10,7 +10,7 @@ The router is optimized for high performance and a small memory footprint. It sc
 
 **Only explicit matches:** With other routers, like [`http.ServeMux`][http.ServeMux], a requested URL path could match multiple patterns. Therefore they have some awkward pattern priority rules, like *longest match* or *first registered, first matched*. By design of this router, a request can only match exactly one or no route. As a result, there are also no unintended matches, which makes it great for SEO and improves the user experience.
 
-**Stop caring about trailing slashes:** Choose the URL style you like, the router automatically redirects the client if a trailing slash is missing or if there is one extra. Of course it only does so, if the new path has a handler. If you don't like it, you can [turn off this behavior](https://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash).
+**Stop caring about trailing slashes:** Choose the URL style you like, the router automatically redirects the client if a trailing slash is missing or if there is one extra. Of course it only does so, if the new path has a handler. If you don't like it, you can [turn off this behavior](https://godoc.org/github.com/bouk/httprouter#Router.RedirectTrailingSlash).
 
 **Path auto-correction:** Besides detecting the missing or additional trailing slash at no extra cost, the router can also fix wrong cases and remove superfluous path elements (like `../` or `//`). Is [CAPTAIN CAPS LOCK](http://www.urbandictionary.com/define.php?term=Captain+Caps+Lock) one of your users? HttpRouter can help him by making a case-insensitive look-up and redirecting him to the correct URL.
 
@@ -24,11 +24,11 @@ The router is optimized for high performance and a small memory footprint. It sc
 
 **Perfect for APIs:** The router design encourages to build sensible, hierarchical RESTful APIs. Moreover it has builtin native support for [OPTIONS requests](http://zacstewart.com/2012/04/14/http-options-method.html) and `405 Method Not Allowed` replies.
 
-Of course you can also set **custom [`NotFound`][Router.NotFound] and  [`MethodNotAllowed`](https://godoc.org/github.com/julienschmidt/httprouter#Router.MethodNotAllowed) handlers** and [**serve static files**][Router.ServeFiles].
+Of course you can also set **custom [`NotFound`][Router.NotFound] and  [`MethodNotAllowed`](https://godoc.org/github.com/bouk/httprouter#Router.MethodNotAllowed) handlers** and [**serve static files**][Router.ServeFiles].
 
 ## Usage
 
-This is just a quick introduction, view the [GoDoc](http://godoc.org/github.com/julienschmidt/httprouter) for details.
+This is just a quick introduction, view the [GoDoc](http://godoc.org/github.com/bouk/httprouter) for details.
 
 Let's start with a trivial example:
 
@@ -37,17 +37,17 @@ package main
 
 import (
     "fmt"
-    "github.com/julienschmidt/httprouter"
+    "github.com/bouk/httprouter"
     "net/http"
     "log"
 )
 
-func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func Index(w http.ResponseWriter, r *http.Request) {
     fmt.Fprint(w, "Welcome!\n")
 }
 
-func Hello(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-    fmt.Fprintf(w, "hello, %s!\n", ps.ByName("name"))
+func Hello(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "hello, %s!\n", httprouter.GetParam(r, "name"))
 }
 
 func main() {
@@ -61,8 +61,7 @@ func main() {
 
 ### Named parameters
 
-As you can see, `:name` is a *named parameter*. The values are accessible via `httprouter.Params`, which is just a slice of `httprouter.Param`s. You can get the value of a parameter either by its index in the slice, or by using the `ByName(name)` method: `:name` can be retrived by `ByName("name")`.
-
+As you can see, `:name` is a *named parameter*. The values are accessible via `httprouter.GetParam`, which returns the value of the given key. Additionally you can access the `httprouter.Params` slice through `httprouter.GetParams`, which allows you to access the parameters by index.
 Named parameters only match a single path segment:
 
 ```
@@ -189,17 +188,17 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
+	"github.com/bouk/httprouter"
 )
 
 func BasicAuth(h httprouter.Handle, requiredUser, requiredPassword string) httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		// Get the Basic Authentication credentials
 		user, password, hasAuth := r.BasicAuth()
 
 		if hasAuth && user == requiredUser && password == requiredPassword {
 			// Delegate request to the given handle
-			h(w, r, ps)
+			h(w, r)
 		} else {
 			// Request Basic Authentication otherwise
 			w.Header().Set("WWW-Authenticate", "Basic realm=Restricted")
@@ -264,13 +263,13 @@ If the HttpRouter is a bit too minimalistic for you, you might try one of the fo
 * [siesta](https://github.com/VividCortex/siesta): Composable HTTP handlers with contexts
 * [xmux](https://github.com/rs/xmux): xmux is a httprouter fork on top of xhandler (net/context aware)
 
-[benchmark]: <https://github.com/julienschmidt/go-http-routing-benchmark>
+[benchmark]: <https://github.com/bouk/go-http-routing-benchmark>
 [http.Handler]: <https://golang.org/pkg/net/http/#Handler
 [http.ServeMux]: <https://golang.org/pkg/net/http/#ServeMux>
-[Router.Handle]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.Handle>
-[Router.HandleMethodNotAllowed]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.HandleMethodNotAllowed>
-[Router.Handler]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.Handler>
-[Router.HandlerFunc]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.HandlerFunc>
-[Router.NotFound]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.NotFound>
-[Router.PanicHandler]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.PanicHandler>
-[Router.ServeFiles]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.ServeFiles>
+[Router.Handle]: <https://godoc.org/github.com/bouk/httprouter#Router.Handle>
+[Router.HandleMethodNotAllowed]: <https://godoc.org/github.com/bouk/httprouter#Router.HandleMethodNotAllowed>
+[Router.Handler]: <https://godoc.org/github.com/bouk/httprouter#Router.Handler>
+[Router.HandlerFunc]: <https://godoc.org/github.com/bouk/httprouter#Router.HandlerFunc>
+[Router.NotFound]: <https://godoc.org/github.com/bouk/httprouter#Router.NotFound>
+[Router.PanicHandler]: <https://godoc.org/github.com/bouk/httprouter#Router.PanicHandler>
+[Router.ServeFiles]: <https://godoc.org/github.com/bouk/httprouter#Router.ServeFiles>

--- a/params.go
+++ b/params.go
@@ -1,0 +1,57 @@
+package httprouter
+
+import (
+	"context"
+	"net/http"
+)
+
+// Param is a single URL parameter, consisting of a key and a value.
+type Param struct {
+	Key   string
+	Value string
+}
+
+// Params is a Param-slice, as returned by the router.
+// The slice is ordered, the first URL parameter is also the first slice value.
+// It is therefore safe to read values by the index.
+type Params []Param
+
+// ByName returns the value of the first Param which key matches the given name.
+// If no matching Param is found, an empty string is returned.
+func (ps Params) ByName(name string) string {
+	for i := range ps {
+		if ps[i].Key == name {
+			return ps[i].Value
+		}
+	}
+	return ""
+}
+
+type paramsContextKey struct{}
+
+// WithParams returns a new Context that contains ps.
+func WithParams(ctx context.Context, ps Params) context.Context {
+	return context.WithValue(ctx, paramsContextKey{}, ps)
+}
+
+// GetParams returns the Params from the Context of the Request.
+func GetParams(req *http.Request) Params {
+	return GetParamsFromContext(req.Context())
+}
+
+// GetParamsFromContext returns the Params from the Context.
+func GetParamsFromContext(ctx context.Context) Params {
+	ps, _ := ctx.Value(paramsContextKey{}).(Params)
+	return ps
+}
+
+// GetParam returns the value of the first Param which key matches in the Context
+// of the Request.
+func GetParam(req *http.Request, key string) string {
+	return GetParamFromContext(req.Context(), key)
+}
+
+// GetParam returns the value of the first Param which key matches in the Context.
+func GetParamFromContext(ctx context.Context, key string) string {
+	return GetParamsFromContext(ctx).ByName(key)
+}

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,51 @@
+package httprouter
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestParams(t *testing.T) {
+	ps := Params{
+		Param{"param1", "value1"},
+		Param{"param2", "value2"},
+		Param{"param3", "value3"},
+	}
+	for i := range ps {
+		if val := ps.ByName(ps[i].Key); val != ps[i].Value {
+			t.Errorf("Wrong value for %s: Got %s; Want %s", ps[i].Key, val, ps[i].Value)
+		}
+	}
+	if val := ps.ByName("noKey"); val != "" {
+		t.Errorf("Expected empty string for not found key; got: %s", val)
+	}
+}
+
+func TestContextParams(t *testing.T) {
+	ps := Params{
+		Param{"param1", "value1"},
+		Param{"param2", "value2"},
+		Param{"param3", "value3"},
+	}
+	req, _ := http.NewRequest("GET", "/whatever", nil)
+	req = req.WithContext(WithParams(req.Context(), ps))
+	for i := range ps {
+		if val := GetParam(req, ps[i].Key); val != ps[i].Value {
+			t.Errorf("Wrong value for %s: Got %s; Want %s", ps[i].Key, val, ps[i].Value)
+		}
+	}
+	if val := GetParam(req, "noKey"); val != "" {
+		t.Errorf("Expected empty string for not found key; got: %s", val)
+	}
+}
+
+func TestMissingContextParams(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/whatever", nil)
+	if value := GetParam(req, "whatever"); value != "" {
+		t.Fatalf("wrong empty parameter value: got %v", value)
+	}
+	ps := GetParams(req)
+	if value := ps.ByName("whatever"); value != "" {
+		t.Fatalf("wrong empty parameter value: got %v", value)
+	}
+}

--- a/router.go
+++ b/router.go
@@ -10,17 +10,17 @@
 //
 //  import (
 //      "fmt"
-//      "github.com/julienschmidt/httprouter"
+//      "github.com/bouk/httprouter"
 //      "net/http"
 //      "log"
 //  )
 //
-//  func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+//  func Index(w http.ResponseWriter, r *http.Request) {
 //      fmt.Fprint(w, "Welcome!\n")
 //  }
 //
-//  func Hello(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-//      fmt.Fprintf(w, "hello, %s!\n", ps.ByName("name"))
+//  func Hello(w http.ResponseWriter, r *http.Request) {
+//      fmt.Fprintf(w, "hello, %s!\n", httprouter.GetParam(r, "name"))
 //  }
 //
 //  func main() {
@@ -79,33 +79,6 @@ package httprouter
 import (
 	"net/http"
 )
-
-// Handle is a function that can be registered to a route to handle HTTP
-// requests. Like http.HandlerFunc, but has a third parameter for the values of
-// wildcards (variables).
-type Handle func(http.ResponseWriter, *http.Request, Params)
-
-// Param is a single URL parameter, consisting of a key and a value.
-type Param struct {
-	Key   string
-	Value string
-}
-
-// Params is a Param-slice, as returned by the router.
-// The slice is ordered, the first URL parameter is also the first slice value.
-// It is therefore safe to read values by the index.
-type Params []Param
-
-// ByName returns the value of the first Param which key matches the given name.
-// If no matching Param is found, an empty string is returned.
-func (ps Params) ByName(name string) string {
-	for i := range ps {
-		if ps[i].Key == name {
-			return ps[i].Value
-		}
-	}
-	return ""
-}
 
 // Router is a http.Handler which can be used to dispatch requests to different
 // handler functions via configurable routes
@@ -176,37 +149,37 @@ func New() *Router {
 }
 
 // GET is a shortcut for router.Handle("GET", path, handle)
-func (r *Router) GET(path string, handle Handle) {
+func (r *Router) GET(path string, handle http.HandlerFunc) {
 	r.Handle("GET", path, handle)
 }
 
 // HEAD is a shortcut for router.Handle("HEAD", path, handle)
-func (r *Router) HEAD(path string, handle Handle) {
+func (r *Router) HEAD(path string, handle http.HandlerFunc) {
 	r.Handle("HEAD", path, handle)
 }
 
 // OPTIONS is a shortcut for router.Handle("OPTIONS", path, handle)
-func (r *Router) OPTIONS(path string, handle Handle) {
+func (r *Router) OPTIONS(path string, handle http.HandlerFunc) {
 	r.Handle("OPTIONS", path, handle)
 }
 
 // POST is a shortcut for router.Handle("POST", path, handle)
-func (r *Router) POST(path string, handle Handle) {
+func (r *Router) POST(path string, handle http.HandlerFunc) {
 	r.Handle("POST", path, handle)
 }
 
 // PUT is a shortcut for router.Handle("PUT", path, handle)
-func (r *Router) PUT(path string, handle Handle) {
+func (r *Router) PUT(path string, handle http.HandlerFunc) {
 	r.Handle("PUT", path, handle)
 }
 
 // PATCH is a shortcut for router.Handle("PATCH", path, handle)
-func (r *Router) PATCH(path string, handle Handle) {
+func (r *Router) PATCH(path string, handle http.HandlerFunc) {
 	r.Handle("PATCH", path, handle)
 }
 
 // DELETE is a shortcut for router.Handle("DELETE", path, handle)
-func (r *Router) DELETE(path string, handle Handle) {
+func (r *Router) DELETE(path string, handle http.HandlerFunc) {
 	r.Handle("DELETE", path, handle)
 }
 
@@ -218,7 +191,11 @@ func (r *Router) DELETE(path string, handle Handle) {
 // This function is intended for bulk loading and to allow the usage of less
 // frequently used, non-standardized or custom methods (e.g. for internal
 // communication with a proxy).
-func (r *Router) Handle(method, path string, handle Handle) {
+func (r *Router) Handle(method, path string, handle http.HandlerFunc) {
+	r.Handler(method, path, handle)
+}
+
+func (r *Router) Handler(method, path string, handler http.Handler) {
 	if path[0] != '/' {
 		panic("path must begin with '/' in path '" + path + "'")
 	}
@@ -233,23 +210,7 @@ func (r *Router) Handle(method, path string, handle Handle) {
 		r.trees[method] = root
 	}
 
-	root.addRoute(path, handle)
-}
-
-// Handler is an adapter which allows the usage of an http.Handler as a
-// request handle.
-func (r *Router) Handler(method, path string, handler http.Handler) {
-	r.Handle(method, path,
-		func(w http.ResponseWriter, req *http.Request, _ Params) {
-			handler.ServeHTTP(w, req)
-		},
-	)
-}
-
-// HandlerFunc is an adapter which allows the usage of an http.HandlerFunc as a
-// request handle.
-func (r *Router) HandlerFunc(method, path string, handler http.HandlerFunc) {
-	r.Handler(method, path, handler)
+	root.addRoute(path, handler)
 }
 
 // ServeFiles serves files from the given file system root.
@@ -269,8 +230,8 @@ func (r *Router) ServeFiles(path string, root http.FileSystem) {
 
 	fileServer := http.FileServer(root)
 
-	r.GET(path, func(w http.ResponseWriter, req *http.Request, ps Params) {
-		req.URL.Path = ps.ByName("filepath")
+	r.GET(path, func(w http.ResponseWriter, req *http.Request) {
+		req.URL.Path = GetParam(req, "filepath")
 		fileServer.ServeHTTP(w, req)
 	})
 }
@@ -286,7 +247,9 @@ func (r *Router) recv(w http.ResponseWriter, req *http.Request) {
 // If the path was found, it returns the handle function and the path parameter
 // values. Otherwise the third return value indicates whether a redirection to
 // the same path with an extra / without the trailing slash should be performed.
-func (r *Router) Lookup(method, path string) (Handle, Params, bool) {
+// It should be noted that the handler won't have access to the Params, unless
+// you add it to the request using WithParams
+func (r *Router) Lookup(method, path string) (http.Handler, Params, bool) {
 	if root := r.trees[method]; root != nil {
 		return root.getValue(path)
 	}
@@ -341,7 +304,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if root := r.trees[req.Method]; root != nil {
 		if handle, ps, tsr := root.getValue(path); handle != nil {
-			handle(w, req, ps)
+			req = req.WithContext(WithParams(req.Context(), ps))
+			handle.ServeHTTP(w, req)
 			return
 		} else if req.Method != "CONNECT" && path != "/" {
 			code := 301 // Permanent redirect, request with GET method

--- a/tree.go
+++ b/tree.go
@@ -5,6 +5,7 @@
 package httprouter
 
 import (
+	"net/http"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -47,7 +48,7 @@ type node struct {
 	maxParams uint8
 	indices   string
 	children  []*node
-	handle    Handle
+	handle    http.Handler
 	priority  uint32
 }
 
@@ -79,7 +80,7 @@ func (n *node) incrementChildPrio(pos int) int {
 
 // addRoute adds a node with the given handle to the path.
 // Not concurrency-safe!
-func (n *node) addRoute(path string, handle Handle) {
+func (n *node) addRoute(path string, handle http.Handler) {
 	fullPath := path
 	n.priority++
 	numParams := countParams(path)
@@ -202,7 +203,7 @@ func (n *node) addRoute(path string, handle Handle) {
 	}
 }
 
-func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle) {
+func (n *node) insertChild(numParams uint8, path, fullPath string, handle http.Handler) {
 	var offset int // already handled bytes of the path
 
 	// find prefix until first wildcard (beginning with ':'' or '*'')
@@ -320,7 +321,7 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
-func (n *node) getValue(path string) (handle Handle, p Params, tsr bool) {
+func (n *node) getValue(path string) (handle http.Handler, p Params, tsr bool) {
 walk: // outer loop for walking the tree
 	for {
 		if len(path) > len(n.path) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -25,10 +25,10 @@ func printChildren(n *node, prefix string) {
 // Used as a workaround since we can't compare functions or their addresses
 var fakeHandlerValue string
 
-func fakeHandler(val string) Handle {
-	return func(http.ResponseWriter, *http.Request, Params) {
+func fakeHandler(val string) http.Handler {
+	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		fakeHandlerValue = val
-	}
+	})
 }
 
 type testRequests []struct {
@@ -49,7 +49,7 @@ func checkRequests(t *testing.T, tree *node, requests testRequests) {
 		} else if request.nilHandler {
 			t.Errorf("handle mismatch for route '%s': Expected nil handle", request.path)
 		} else {
-			handler(nil, nil, nil)
+			handler.ServeHTTP(nil, nil)
 			if fakeHandlerValue != request.route {
 				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
 			}


### PR DESCRIPTION
This has plenty of benefits, it makes middlewares pass through the
Params for example. I have simplified the API a bit by removing the
Handler type (it now just uses http.Handler everywhere) and by removing
HandlerFunc from Router. This is an API-breaking change.

Add GetParam, GetParams.
Add GetParamFromContext, GetParamsFromContext.